### PR TITLE
Feature/5/as an administrator i can delete a user account

### DIFF
--- a/src/main/java/su/dikunia/zabbix_clone/controllers/api/UserController.java
+++ b/src/main/java/su/dikunia/zabbix_clone/controllers/api/UserController.java
@@ -15,6 +15,7 @@ import su.dikunia.zabbix_clone.dto.UserDTO;
 import su.dikunia.zabbix_clone.enums.RoleName;
 import su.dikunia.zabbix_clone.service.UserService;
 
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -52,6 +53,15 @@ public class UserController {
 
         userService.changeUserPassword(user_id, newPassword);
         return ResponseEntity.ok("Пользователю выдан новый пароль!");
+    }
+
+    @DeleteMapping("/archive")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<String> archiveUser(@RequestParam String login, @RequestParam(defaultValue = "30") int retentionDays) {
+        System.out.println("Админ удаляет учетную запись пользователя!");
+
+        userService.archiveUser(login, retentionDays);
+        return ResponseEntity.ok("Учатная запись " + login + "была удалена!");
     }
     
 }

--- a/src/main/java/su/dikunia/zabbix_clone/controllers/api/UserController.java
+++ b/src/main/java/su/dikunia/zabbix_clone/controllers/api/UserController.java
@@ -60,8 +60,11 @@ public class UserController {
     public ResponseEntity<String> archiveUser(@RequestParam String login, @RequestParam(defaultValue = "30") int retentionDays) {
         System.out.println("Админ удаляет учетную запись пользователя!");
 
-        userService.archiveUser(login, retentionDays);
-        return ResponseEntity.ok("Учатная запись " + login + "была удалена!");
+        try {
+            userService.archiveUser(login, retentionDays);
+            return ResponseEntity.ok("Учатная запись " + login + "была удалена!");
+        } catch (IllegalStateException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
     }
-    
 }

--- a/src/main/java/su/dikunia/zabbix_clone/domain/UserEntity.java
+++ b/src/main/java/su/dikunia/zabbix_clone/domain/UserEntity.java
@@ -49,5 +49,11 @@ public class UserEntity {
     @JoinColumn(name = "role_id", nullable = false)
     private RoleEntity roleEntity;
 
+    @Column(name = "is_deleted")
+    private boolean deleted = false;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
     public UserEntity() {}
 }

--- a/src/main/java/su/dikunia/zabbix_clone/repos/UserRepository.java
+++ b/src/main/java/su/dikunia/zabbix_clone/repos/UserRepository.java
@@ -21,4 +21,7 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
 
     @Query("SELECT u FROM UserEntity u WHERE u.deleted = true AND u.deletedAt <= :thresholdDate")
     List<UserEntity> findDeletedBefore(@Param("thresholdDate") LocalDateTime thresholdDate);
+
+    @Query("SELECT COUNT(u) FROM UserEntity u WHERE u.roleEntity.name = 'ADMIN' AND u.deleted = false")
+    long countActiveAdmins();
 }

--- a/src/main/java/su/dikunia/zabbix_clone/repos/UserRepository.java
+++ b/src/main/java/su/dikunia/zabbix_clone/repos/UserRepository.java
@@ -1,11 +1,24 @@
 package su.dikunia.zabbix_clone.repos;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import su.dikunia.zabbix_clone.domain.UserEntity;
 
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
     Optional<UserEntity> findByLogin(String login);
+
+    @Query("SELECT u FROM UserEntity u WHERE u.deleted = false")
+    List<UserEntity> findAllActive();
+
+    @Query("SELECT u FROM UserEntity u")
+    List<UserEntity> findAllIncludingDeleted();
+
+    @Query("SELECT u FROM UserEntity u WHERE u.deleted = true AND u.deletedAt <= :thresholdDate")
+    List<UserEntity> findDeletedBefore(@Param("thresholdDate") LocalDateTime thresholdDate);
 }

--- a/src/main/java/su/dikunia/zabbix_clone/service/DeletionScheduler.java
+++ b/src/main/java/su/dikunia/zabbix_clone/service/DeletionScheduler.java
@@ -1,0 +1,26 @@
+package su.dikunia.zabbix_clone.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import jakarta.transaction.Transactional;
+import su.dikunia.zabbix_clone.domain.UserEntity;
+import su.dikunia.zabbix_clone.repos.UserRepository;
+
+@Service
+public class DeletionScheduler {
+    @Autowired
+    private UserRepository userRepository;
+
+    @Scheduled(cron = "0 0 3 1 * ?")
+    @Transactional
+    public void deleteArchivedUsers() {
+        LocalDateTime timeLimit = LocalDateTime.now();
+        List<UserEntity> usersToDelete = userRepository.findDeletedBefore(timeLimit);
+        userRepository.deleteAll(usersToDelete);
+    }
+}

--- a/src/main/java/su/dikunia/zabbix_clone/service/UserService.java
+++ b/src/main/java/su/dikunia/zabbix_clone/service/UserService.java
@@ -75,6 +75,13 @@ public class UserService {
     public void archiveUser(String login, int retentionDays) {
         UserEntity user = userRepository.findByLogin(login)
                 .orElseThrow(() -> new EntityNotFoundException("User not found"));
+        if (user.getRoleEntity().getName() == RoleName.ADMIN) {
+            long activeAdminsCount = userRepository.countActiveAdmins();
+            if (activeAdminsCount <= 1) {
+                throw new IllegalStateException("Cannot delete the last admin account!");
+            }
+        }
+        
         user.setDeleted(true);
         user.setDeletedAt(LocalDateTime.now().plusDays(retentionDays));
         userRepository.save(user);

--- a/src/main/java/su/dikunia/zabbix_clone/service/UserService.java
+++ b/src/main/java/su/dikunia/zabbix_clone/service/UserService.java
@@ -72,8 +72,8 @@ public class UserService {
     }
 
     @Transactional
-    public void archiveUser(Long user_id, int retentionDays) {
-        UserEntity user = userRepository.findById(user_id)
+    public void archiveUser(String login, int retentionDays) {
+        UserEntity user = userRepository.findByLogin(login)
                 .orElseThrow(() -> new EntityNotFoundException("User not found"));
         user.setDeleted(true);
         user.setDeletedAt(LocalDateTime.now().plusDays(retentionDays));

--- a/src/main/java/su/dikunia/zabbix_clone/service/UserService.java
+++ b/src/main/java/su/dikunia/zabbix_clone/service/UserService.java
@@ -1,5 +1,6 @@
 package su.dikunia.zabbix_clone.service;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -68,5 +69,14 @@ public class UserService {
             .orElseThrow(() -> new EntityNotFoundException("User not found!"));
         userEntity.setPassword(passwordEncoder.encode(newPassword));
         userRepository.save(userEntity);
+    }
+
+    @Transactional
+    public void archiveUser(Long user_id, int retentionDays) {
+        UserEntity user = userRepository.findById(user_id)
+                .orElseThrow(() -> new EntityNotFoundException("User not found"));
+        user.setDeleted(true);
+        user.setDeletedAt(LocalDateTime.now().plusDays(retentionDays));
+        userRepository.save(user);
     }
 }

--- a/src/test/java/su/dikunia/zabbix_clone/service/DeletionSchedulerTest.java
+++ b/src/test/java/su/dikunia/zabbix_clone/service/DeletionSchedulerTest.java
@@ -1,0 +1,49 @@
+package su.dikunia.zabbix_clone.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import su.dikunia.zabbix_clone.config.SetupDataLoader;
+import su.dikunia.zabbix_clone.domain.UserEntity;
+import su.dikunia.zabbix_clone.repos.UserRepository;
+
+@SpringBootTest
+@MockBean(SetupDataLoader.class) 
+class DeletionSchedulerTest {
+    static {        
+        System.setProperty("jwt.secret", "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.e30.QwoOdMKxwpjCuC14w47CisOQw74wD8OKw6p7cmjDpsKnHcOfw4lKHcKLZyNjOQ");    
+    }    
+
+    @MockBean
+    private UserRepository userRepository;
+
+    @Autowired
+    private DeletionScheduler deletionScheduler;
+
+    @Test
+    void deleteArchivedUsers_shouldDeleteUsersWithExpiredRetention() {
+        UserEntity expiredUser = new UserEntity();
+        expiredUser.setDeletedAt(LocalDateTime.now().minusDays(1)); 
+
+        UserEntity unexpiredUser = new UserEntity();
+        unexpiredUser.setDeletedAt(LocalDateTime.now().plusDays(1)); 
+
+        when(userRepository.findDeletedBefore(any(LocalDateTime.class)))
+            .thenReturn(Collections.singletonList(expiredUser));
+
+        deletionScheduler.deleteArchivedUsers();
+
+        verify(userRepository, times(1)).deleteAll(Arrays.asList(expiredUser));
+    }
+}

--- a/src/test/java/su/dikunia/zabbix_clone/service/UserServiceTest.java
+++ b/src/test/java/su/dikunia/zabbix_clone/service/UserServiceTest.java
@@ -219,8 +219,12 @@ public class UserServiceTest {
         String login = "login@company.su";
         int retentionDays = 30;
 
+        RoleEntity roleEntity = new RoleEntity();
+        roleEntity.setName(RoleName.STAFF);
+
         UserEntity userEntity = new UserEntity();
         userEntity.setLogin(login);
+        userEntity.setRoleEntity(roleEntity);
         userEntity.setDeleted(false);
         userEntity.setDeletedAt(null);
 
@@ -240,6 +244,25 @@ public class UserServiceTest {
         when(userRepository.findByLogin(login)).thenReturn(Optional.empty());
 
         assertThrows(EntityNotFoundException.class, () -> {
+            userService.archiveUser(login, 30);
+        });
+    }
+
+    @Test
+    void archiveUser_shouldThrowExceptionIfLastAdmin() {
+        String login = "lastAdmin";
+
+        RoleEntity roleEntity = new RoleEntity();
+        roleEntity.setName(RoleName.ADMIN);
+
+        UserEntity adminUser = new UserEntity();
+        adminUser.setLogin(login);
+        adminUser.setRoleEntity(roleEntity);
+
+        when(userRepository.findByLogin(login)).thenReturn(Optional.of(adminUser));
+        when(userRepository.countActiveAdmins()).thenReturn(1L); // Один активный администратор
+
+        assertThrows(IllegalStateException.class, () -> {
             userService.archiveUser(login, 30);
         });
     }

--- a/src/test/java/su/dikunia/zabbix_clone/service/UserServiceTest.java
+++ b/src/test/java/su/dikunia/zabbix_clone/service/UserServiceTest.java
@@ -214,5 +214,34 @@ public class UserServiceTest {
         );
     }
 
+    @Test
+    void archiveUser_shouldSetDeletedAndDeletedAt() {
+        String login = "login@company.su";
+        int retentionDays = 30;
+
+        UserEntity userEntity = new UserEntity();
+        userEntity.setLogin(login);
+        userEntity.setDeleted(false);
+        userEntity.setDeletedAt(null);
+
+        when(userRepository.findByLogin(login)).thenReturn(Optional.of(userEntity));
+        userService.archiveUser(login, retentionDays);
+
+        assertTrue(userEntity.isDeleted());
+        assertNotNull(userEntity.getDeletedAt());
+        assertEquals(LocalDateTime.now().plusDays(retentionDays).toLocalDate(), userEntity.getDeletedAt().toLocalDate());
+        verify(userRepository, times(1)).save(userEntity);
+    }
+
+    @Test
+    void archiveUser_shouldThrowExceptionIfUserNotFound() {
+        String login = "nonExistentUser";
+
+        when(userRepository.findByLogin(login)).thenReturn(Optional.empty());
+
+        assertThrows(EntityNotFoundException.class, () -> {
+            userService.archiveUser(login, 30);
+        });
+    }
 }
     


### PR DESCRIPTION
Добавлен функционал мягкого удаления учетной записи пользователя:
- UserEntity приобрел два поля: boolean deleted и LocalDateTime deletedAt. Первое поле по умолчанию false, а второе поле получает дату/время, когда первое приобрело значение True.
- UserRepository приобрело дополнительные методы поиска учетных записей, помеченных на удаление и счетчик текущего количества администраторов в системе (по ТЗ, последний админ не удаляемый)
- DeletionScheduler - класс-планировщик, который через cron-выражение спустя заданное время удаляет тех пользователей, у которых истек срок содержания в архиве для мягкого удаления
- UserService.archiveUser проверяет поступающего в метод пользователя, не является ли он последним администратором и потом помечает его на удаление: boolean deleted = True и LocalDateTime deletedAt = дата/время на момент выполнения метода
- UserController.archiveUser принимает логин пользователя и количество времени, после которого юзеры в архиве подлежат удалению, и вызывает метод UserService.archiveUser. Если передали логин последнего админа, то возвращается сообщение об ошибке. В других случаях возвращается код 200
- Новые классы и методы покрыты тестами