### PR TITLE
исправлена ошибка, из-за которого приложение могло не работать: так к…

### DIFF
--- a/src/main/java/su/dikunia/zabbix_clone/domain/UserEntity.java
+++ b/src/main/java/su/dikunia/zabbix_clone/domain/UserEntity.java
@@ -49,7 +49,7 @@ public class UserEntity {
     @JoinColumn(name = "role_id", nullable = false)
     private RoleEntity roleEntity;
 
-    @Column(name = "is_deleted")
+    @Column(name = "is_deleted", nullable = false)
     private boolean deleted = false;
 
     @Column(name = "deleted_at")


### PR DESCRIPTION
…ак в UserEntity используется примитивный тип boolean, то могут быть записи в таблице БД, у которых этот флаг не был назначен по умолчанию (учетные записи создались раньше момента, когад было внесено в код это поле) и Бд пыталось присвоить ему значение null, что для простого булевого типа данных неприемлимо